### PR TITLE
Don't leak `version.py`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(cwt-cucumber VERSION 2.8)
 
 set(version_content "version = \"${PROJECT_VERSION}\"\n")
-file(WRITE "${CMAKE_SOURCE_DIR}/docs/_version.py" "${version_content}")
+file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/docs/_version.py" "${version_content}")
 
 option(CUCUMBER_BUILD_TESTS_AND_EXAMPLES "Enable example and test targets" ON)
 option(CUCUMBER_UNDEFINED_STEPS_ARE_A_FAILURE "The overall result will fail if the tests contain undefined steps" ON)


### PR DESCRIPTION
When using this project in another ones (e.g. with submodules) `docs/_version.py` leaks into the project root directory 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for improved consistency in file generation paths during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->