### PR TITLE
Fix: Empty cells in table

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior in cwt-cucumber
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Description
+A brief and clear description of the bug.
+
+## Minimal Reproducible Example
+
+**Feature file:**
+```gherkin
+Feature: ...
+
+  Scenario: ...
+    Given ...
+```
+
+**Step definition:**
+```cpp
+GIVEN(my_step, "...")
+{
+  // ...
+}
+```
+
+## Expected Behavior
+What did you expect to happen?
+
+## Actual Behavior
+What actually happened? Include any error messages or output.
+
+```
+(paste output here)
+```
+
+## Environment (optional)
+- **OS:** (e.g. Ubuntu 24.04, macOS 15, Windows 11)
+- **Compiler:** (e.g. GCC 13, Clang 17, MSVC 19)
+- **cwt-cucumber version / commit:** 
+
+## Additional Context
+Any other context, workarounds you tried, or related issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,38 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for cwt-cucumber
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+## Summary
+A short, clear description of the feature you'd like to see.
+
+## Motivation
+Why is this feature useful? What problem does it solve, or what use case does it enable?
+
+## Proposed API / Behavior (optional)
+If you have an idea how this could look, show it here. Examples are very welcome.
+
+**Feature file:**
+```gherkin
+Feature: ...
+
+  Scenario: ...
+    Given ...
+```
+
+**Step definition:**
+```cpp
+GIVEN(my_step, "...")
+{
+  // ...
+}
+```
+
+## Alternatives Considered (optional)
+Have you found any workarounds or alternative approaches? Why are they not sufficient?
+
+## Additional Context (optional)
+Links to related Cucumber specs, other implementations, or any other context that might help.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,25 @@
+---
+name: Question
+about: Ask a question about usage, integration, or behavior of cwt-cucumber
+title: "[Question] "
+labels: question
+assignees: ""
+---
+
+## Question
+What would you like to know?
+
+## Context
+What are you trying to achieve? A brief description helps give a more useful answer.
+
+## What I've Tried
+Describe what you've already tried or looked at (docs, examples, other issues).
+
+**Relevant code snippet (if applicable):**
+```cpp
+// ...
+```
+
+```gherkin
+# ...
+```

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,8 +1,6 @@
 name: Formatting
 
 on:
-  push:
-    branches: [ "**" ]
   pull_request:
     branches: [ "**" ] 
     

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -2,7 +2,7 @@ name: Build & Test
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "**" ] 
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Tags with hyphens are not parsed correctly ([111](https://github.com/ThoSe1990/cwt-cucumber/pull/111))
 - Removed Cucumber prints to `stdout` when using `--report-json`, only JSON report is printed to stdout. No prints when printing JSON results to a file ([108](https://github.com/ThoSe1990/cwt-cucumber/pull/108))
+- Parser fails with empty table cells in data tables or Scenario Outlines ([116](https://github.com/ThoSe1990/cwt-cucumber/pull/116))
 
 ## [2.8] 2025-11-21
 

--- a/docs/chapters/cucumber_features.rst
+++ b/docs/chapters/cucumber_features.rst
@@ -62,7 +62,7 @@ Placeholders inside the scenario are replaced by values defined in the ``Example
       | orange | 3     |
 
 Each row in the ``Examples`` table executes the scenario once,  
-substituting the placeholders ``<item>`` and ``<count>`` accordingly.
+substituting the placeholders ``<item>`` and ``<count>`` accordingly. Empty cells are considered as empty strings.
 
 Background
 ----------

--- a/docs/chapters/step_definitions.rst
+++ b/docs/chapters/step_definitions.rst
@@ -347,7 +347,7 @@ You can access a table attached to a step using the macro ``CUKE_TABLE()``:
 - As a const reference: ``const cuke::table& t = CUKE_TABLE();``  
 - As a copy: ``cuke::table t = CUKE_TABLE();``
 
-The table contains ``cuke::value`` objects. You can access values with ``operator[]`` and convert them using ``as<>()`` or ``to_string()``:
+The table contains ``cuke::value`` objects. Empty tables are considered as empty strings. You can access values with ``operator[]`` and convert them using ``as<>()`` or ``to_string()``:
 
 .. code-block:: cpp
 

--- a/gtest/ast.cc
+++ b/gtest/ast.cc
@@ -842,7 +842,7 @@ TEST(ast, parse_cell_empty_cell)
 
   cuke::value v = cuke::internal::parse_cell(lex, false);
   EXPECT_TRUE(v.is_nil());
-  EXPECT_TRUE(lex.error());
+  EXPECT_TRUE(v.as<std::string>().empty());
 }
 TEST(ast, scenario_outline_w_example)
 {

--- a/gtest/step_finder.cc
+++ b/gtest/step_finder.cc
@@ -46,6 +46,12 @@ TEST(step_finder, step_with_string)
         step_finder("or a trailing \"string value\"").step_matches(pattern));
   }
   {
+    auto [pattern, types] =
+        create_regex_definition("just an empty string {string} here");
+    EXPECT_TRUE(
+        step_finder("just an empty string \"\" here").step_matches(pattern));
+  }
+  {
     auto [pattern, types] = create_regex_definition(
         "{string} at the beginning, {string} inside and a trailing {string}");
     EXPECT_TRUE(

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -128,8 +128,7 @@ template <typename... Ts>
 
   if (count == 0)
   {
-    lex.error_at(lex.current(), "Expect value in table cell");
-    return {};
+    return cuke::value(std::string{});
   }
 
   cuke::value v(create_string(begin, lex.previous()));

--- a/src/registry.hpp
+++ b/src/registry.hpp
@@ -280,22 +280,22 @@ class registry
          {"(-?\\d*\\.?\\d+)", "double", make_parameter_value<double>}},
         {"{word}",
          {"([^\\s]*)", "word",
-          [](cuke::value_array::const_iterator begin,
-             std::size_t count) -> any
+          [](cuke::value_array::const_iterator begin, std::size_t count) -> any
           {
-            std::string val = get_param_value(begin, count, 1).as<std::string>();
+            std::string val =
+                get_param_value(begin, count, 1).as<std::string>();
             return (val == "\"\"") ? std::string{} : val;
           }}},
         {"{string}",
          {"\"([^\"]*)\"", "string", make_parameter_value<std::string>}},
-        {"{}", {"(.*)", "anonymous",
-                [](cuke::value_array::const_iterator begin,
-                   std::size_t count) -> any
-                {
-                  std::string val =
-                      get_param_value(begin, count, 1).as<std::string>();
-                  return (val == "\"\"") ? std::string{} : val;
-                }}}};
+        {"{}",
+         {"(.*)", "anonymous",
+          [](cuke::value_array::const_iterator begin, std::size_t count) -> any
+          {
+            std::string val =
+                get_param_value(begin, count, 1).as<std::string>();
+            return (val == "\"\"") ? std::string{} : val;
+          }}}};
     std::unordered_map<std::string, expression> custom;
   } m_expressions;
 };

--- a/src/registry.hpp
+++ b/src/registry.hpp
@@ -278,10 +278,24 @@ class registry
         {"{float}", {"(-?\\d*\\.?\\d+)", "float", make_parameter_value<float>}},
         {"{double}",
          {"(-?\\d*\\.?\\d+)", "double", make_parameter_value<double>}},
-        {"{word}", {"([^\\s]+)", "word", make_parameter_value<std::string>}},
+        {"{word}",
+         {"([^\\s]*)", "word",
+          [](cuke::value_array::const_iterator begin,
+             std::size_t count) -> any
+          {
+            std::string val = get_param_value(begin, count, 1).as<std::string>();
+            return (val == "\"\"") ? std::string{} : val;
+          }}},
         {"{string}",
          {"\"([^\"]*)\"", "string", make_parameter_value<std::string>}},
-        {"{}", {"(.+)", "anonymous", make_parameter_value<std::string>}}};
+        {"{}", {"(.*)", "anonymous",
+                [](cuke::value_array::const_iterator begin,
+                   std::size_t count) -> any
+                {
+                  std::string val =
+                      get_param_value(begin, count, 1).as<std::string>();
+                  return (val == "\"\"") ? std::string{} : val;
+                }}}};
     std::unordered_map<std::string, expression> custom;
   } m_expressions;
 };

--- a/src/registry.hpp
+++ b/src/registry.hpp
@@ -39,6 +39,13 @@ static any make_parameter_value(cuke::value_array::const_iterator begin,
   return get_param_value(begin, count, 1).as<T>();
 }
 
+static any make_parameter_from_words_and_anonymous(
+    cuke::value_array::const_iterator begin, std::size_t count)
+{
+  std::string val = get_param_value(begin, count, 1).as<std::string>();
+  return (val == "\"\"") ? std::string{} : val;
+}
+
 template <typename Hook>
 static void run_hook(const std::vector<Hook>& hooks)
 {
@@ -279,23 +286,10 @@ class registry
         {"{double}",
          {"(-?\\d*\\.?\\d+)", "double", make_parameter_value<double>}},
         {"{word}",
-         {"([^\\s]*)", "word",
-          [](cuke::value_array::const_iterator begin, std::size_t count) -> any
-          {
-            std::string val =
-                get_param_value(begin, count, 1).as<std::string>();
-            return (val == "\"\"") ? std::string{} : val;
-          }}},
+         {"([^\\s]*)", "word", make_parameter_from_words_and_anonymous}},
         {"{string}",
          {"\"([^\"]*)\"", "string", make_parameter_value<std::string>}},
-        {"{}",
-         {"(.*)", "anonymous",
-          [](cuke::value_array::const_iterator begin, std::size_t count) -> any
-          {
-            std::string val =
-                get_param_value(begin, count, 1).as<std::string>();
-            return (val == "\"\"") ? std::string{} : val;
-          }}}};
+        {"{}", {"(.*)", "anonymous", make_parameter_from_words_and_anonymous}}};
     std::unordered_map<std::string, expression> custom;
   } m_expressions;
 };

--- a/src/step_finder.cpp
+++ b/src/step_finder.cpp
@@ -21,26 +21,21 @@ step_finder::step_finder(std::string_view feature,
 cuke::value_array& step_finder::values() noexcept { return m_values; }
 bool step_finder::step_matches(const std::string& pattern)
 {
-  bool found = false;
+  std::regex regex_pattern(pattern);
+  std::smatch match;
+  if (std::regex_match(m_feature_string, match, regex_pattern))
   {
-    std::regex regex_pattern(pattern);
-    std::smatch match;
-    std::string text = m_feature_string;
-    while (std::regex_search(text, match, regex_pattern))
+    for (std::size_t i = 1; i < match.size(); ++i)
     {
-      found = true;
-      for (std::size_t i = 1; i < match.size(); ++i)
+      if (!match[i].matched)
       {
-        if (!match[i].matched)
-        {
-          continue;
-        }
-        m_values.push_back(cuke::value(std::string{match[i]}));
+        continue;
       }
-      text = match.suffix().str();
+      m_values.push_back(cuke::value(std::string{match[i]}));
     }
+    return true;
   }
-  return found;
+  return false;
 }
 
 }  // namespace cuke::internal

--- a/src/util_regex.hpp
+++ b/src/util_regex.hpp
@@ -22,7 +22,8 @@ namespace cuke::internal
   {
     result.append(search_start, match[0].first);
     std::string key = match[1].str();
-    result += row[key].to_string();
+    const std::string& value = row[key].to_string();
+    result += value.empty() ? "\"\"" : value;
     search_start = match[0].second;
   }
   result.append(search_start, step.cend());

--- a/stress-tests/features/stress-tests.feature
+++ b/stress-tests/features/stress-tests.feature
@@ -41,3 +41,29 @@ Feature: Stress tests
     which we access 
     as std::vector<std::string>
     """
+
+  Scenario: Empty cells in data table
+    When There is an empty table cell
+      | | | |
+      | | | |
+  
+
+  Scenario Outline: Empty cells in examples
+    When Some values <val1> <val2> and <val3> are empty
+
+    Examples:
+      | val1 | val2 | val3 |
+      |      |      |      |
+      |      |      |      |
+    Examples:
+      | val1 | val2 | val3 |
+      | ""   | ""   | ""   |
+      | ""   | ""   | ""   |
+    Examples:
+      | val1 | val2 | val3 |
+      | ""   | ""   |      |
+      | ""   | ""   |      |
+    Examples:
+      | val1 | val2 | val3 |
+      |      | ""   |      |
+      |      | ""   |      |

--- a/stress-tests/features/stress-tests.feature
+++ b/stress-tests/features/stress-tests.feature
@@ -49,7 +49,7 @@ Feature: Stress tests
   
 
   Scenario Outline: Empty cells in examples
-    When Some values <val1> <val2> and <val3> are empty
+    When Some values <val1>, <val2> and <val3> are empty
 
     Examples:
       | val1 | val2 | val3 |

--- a/stress-tests/step_definition.cpp
+++ b/stress-tests/step_definition.cpp
@@ -64,9 +64,9 @@ WHEN(empty_cells_in_examples, "Some values {word} {} and {string} are empty")
   const std::string word_value = CUKE_ARG(1);
   cuke::is_true(word_value.empty());
 
-  const std::string anonymous_value = CUKE_ARG(1);
+  const std::string anonymous_value = CUKE_ARG(2);
   cuke::is_true(anonymous_value.empty());
 
-  const std::string string_value = CUKE_ARG(1);
+  const std::string string_value = CUKE_ARG(3);
   cuke::is_true(string_value.empty());
 }

--- a/stress-tests/step_definition.cpp
+++ b/stress-tests/step_definition.cpp
@@ -45,3 +45,28 @@ WHEN(doc_string_vector, "There is a doc string as vector:")
   const std::vector<std::string> doc_string = CUKE_DOC_STRING();
   cuke::is_false(doc_string.empty());
 }
+
+WHEN(empty_table_cell, "There is an empty table cell")
+{
+  const auto& table = CUKE_TABLE();
+  for (const auto& row : table.raw())
+  {
+    for (std::size_t i = 0; i < row.col_count(); ++i)
+    {
+      cuke::is_true(row[i].is_nil());
+      cuke::is_true(row[i].as<std::string>().empty());
+    }
+  }
+}
+
+WHEN(empty_cells_in_examples, "Some values {word} {} and {string} are empty")
+{
+  const std::string word_value = CUKE_ARG(1);
+  cuke::is_true(word_value.empty());
+
+  const std::string anonymous_value = CUKE_ARG(1);
+  cuke::is_true(anonymous_value.empty());
+
+  const std::string string_value = CUKE_ARG(1);
+  cuke::is_true(string_value.empty());
+}

--- a/stress-tests/step_definition.cpp
+++ b/stress-tests/step_definition.cpp
@@ -59,7 +59,7 @@ WHEN(empty_table_cell, "There is an empty table cell")
   }
 }
 
-WHEN(empty_cells_in_examples, "Some values {word} {} and {string} are empty")
+WHEN(empty_cells_in_examples, "Some values {word}, {} and {string} are empty")
 {
   const std::string word_value = CUKE_ARG(1);
   cuke::is_true(word_value.empty());


### PR DESCRIPTION
Reported here: https://github.com/ThoSe1990/cwt-cucumber/issues/115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty data-table/Examples cells and empty Scenario Outline values are now handled consistently as empty strings (no longer treated as an error).
  * `{word}` and anonymous `{}` placeholders now allow empty matches, including empty-string substitutions.
  * Step matching was tightened to require full-text regex matches for captured groups.
* **Tests**
  * Expanded stress-test coverage and added new steps to assert nil/empty-string behavior for empty cells and examples.
* **Documentation**
  * Clarified handling of empty cells/values in Scenario Outlines and datatable usage notes.
* **Chores**
  * Updated CI workflow branch triggers and added GitHub issue templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->