### PR TITLE
Tags with special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed 
 
 - Tags with hyphens are not parsed correctly ([111](https://github.com/ThoSe1990/cwt-cucumber/pull/111))
+- Tags with dots are not parsed correctly ([123](https://github.com/ThoSe1990/cwt-cucumber/pull/123))
 - Removed Cucumber prints to `stdout` when using `--report-json`, only JSON report is printed to stdout. No prints when printing JSON results to a file ([108](https://github.com/ThoSe1990/cwt-cucumber/pull/108))
 - Parser fails with empty table cells in data tables or Scenario Outlines ([116](https://github.com/ThoSe1990/cwt-cucumber/pull/116))
 

--- a/gtest/run_scenarios_tags.cc
+++ b/gtest/run_scenarios_tags.cc
@@ -483,3 +483,27 @@ TEST_F(run_scenarios_special_tags, ignore_2)
   EXPECT_EQ(cuke::results::test_results().scenarios_skipped(), 0);
   EXPECT_FALSE(cuke::internal::get_runtime_options().ignore_scenario());
 }
+TEST_F(run_scenarios_special_tags, tag_with_special_chars)
+{
+  const char* script = R"*(
+    Feature: a feature
+    @$*./<>::'|%^&!?_-#
+    Scenario: a scenario
+    Given a step
+ 
+    @my.tag.with.dots
+    Scenario: this runs
+    Given a step
+  )*";
+  cuke::parser p;
+  p.parse_script(script);
+  make_args("@$*./<>::'|%^&!?_-# or @my.tag.with.dots");
+
+  cuke::test_runner runner;
+  p.for_each_scenario(runner);
+
+  ASSERT_EQ(cuke::results::test_results().scenarios_count(), 2);
+  EXPECT_EQ(cuke::results::test_results().scenarios_passed(), 2);
+  EXPECT_EQ(cuke::results::test_results().scenarios_skipped(), 0);
+  EXPECT_FALSE(cuke::internal::get_runtime_options().ignore_scenario());
+}

--- a/gtest/tags.cc
+++ b/gtest/tags.cc
@@ -233,6 +233,18 @@ TEST(tag_expression, tag_with_hyphen)
   ASSERT_EQ(tc.size(), 1);
   EXPECT_EQ(tc[0].value, "@my-tag");
 }
+TEST(tag_expression, tag_with_dots)
+{
+  cuke::internal::tag_expression tc("@my.tag");
+  ASSERT_EQ(tc.size(), 1);
+  EXPECT_EQ(tc[0].value, "@my.tag");
+}
+TEST(tag_expression, tag_with_special_chars)
+{
+  cuke::internal::tag_expression tc("@$*./<>::'|%^&!?_-#");
+  ASSERT_EQ(tc.size(), 1);
+  EXPECT_EQ(tc[0].value, "@$*./<>::'|%^&!?_-#");
+}
 TEST(tag_expression, tag_with_hyphen_and_operator)
 {
   cuke::internal::tag_expression tc("@my-tag and @other-tag");
@@ -473,5 +485,17 @@ TEST(tag_evaluation, hyphenated_tag_and)
 {
   std::vector<std::string> tags{std::string("@tag-1"), std::string("@tag-2")};
   cuke::internal::tag_expression tc("@tag-1 and @tag-2");
+  EXPECT_TRUE(tc.evaluate(tags));
+}
+TEST(tag_evaluation, tags_with_dots)
+{
+  std::vector<std::string> tags{std::string("@tag.1"), std::string("@tag.2")};
+  cuke::internal::tag_expression tc("@tag.1 and @tag.2");
+  EXPECT_TRUE(tc.evaluate(tags));
+}
+TEST(tag_evaluation, tags_with_special_char)
+{
+  std::vector<std::string> tags{std::string("@$*./<>::'|%^&!?_-#")};
+  cuke::internal::tag_expression tc("@$*./<>::'|%^&!?_-#");
   EXPECT_TRUE(tc.evaluate(tags));
 }

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -13,6 +13,14 @@ static bool is_alpha(char c)
 
 static bool is_digit(char c) { return c >= '0' && c <= '9'; }
 
+static bool is_tag_char(char c)
+{
+  return is_alpha(c) || is_digit(c) || c == '-' || c == '.' || c == '#' ||
+         c == '/' || c == ':' || c == '$' || c == '*' || c == '<' || c == '>' ||
+         c == '\'' || c == '|' || c == '%' || c == '^' || c == '&' ||
+         c == '!' || c == '?';
+}
+
 scanner::scanner(std::string_view source) : m_source(source)
 {
   find_language();
@@ -224,7 +232,7 @@ token scanner::number()
 
 token scanner::tag()
 {
-  while (is_alpha(peek()) || is_digit(peek()) || peek() == '-')
+  while (is_tag_char(peek()))
   {
     advance();
   }


### PR DESCRIPTION
First fix to allow special characters in tags. For now the whitelist approach is a good enough solution.
Reported here: https://github.com/ThoSe1990/cwt-cucumber/issues/119
But this still faces the issue that there is no escape logic. Issue https://github.com/ThoSe1990/cwt-cucumber/issues/122 created. This will be done in the future

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scenario tags can now include dotted names and special characters when selecting scenarios.
  * Tag-based filtering now recognizes a broader set of tag formats, making scenario selection more flexible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->