### PR TITLE
Cache compiled step regex to avoid recompiling on every match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - `cuke::current_feature()`, `cuke::current_scenario()` and `cuke::current_step()` to access the feature/scenario/step currently being executed from hooks or step definitions ([125](https://github.com/ThoSe1990/cwt-cucumber/pull/125))
 - `CUKE_DOC_STRING_TYPE()` to access a doc string's content type tag (e.g. `json` in ` ```json`) ([130](https://github.com/ThoSe1990/cwt-cucumber/pull/130))
 
+### Changed
+
+- Step matching now reuses a precompiled regex per step definition instead of recompiling it on every match attempt ([136](https://github.com/ThoSe1990/cwt-cucumber/pull/136))
+
 ### Fixed
 
 - Literal parentheses `()` and curly braces `{}` in step text are not matched; escape them with `\(`, `\)`, `\{`, `\}` to use them literally instead of as optional text or a parameter type ([129](https://github.com/ThoSe1990/cwt-cucumber/pull/129))

--- a/src/step.cpp
+++ b/src/step.cpp
@@ -2,7 +2,6 @@
 
 #include "util_regex.hpp"
 
-#include <iostream>
 namespace cuke::internal
 {
 
@@ -21,6 +20,7 @@ step_definition::step_definition(step_callback cb,
 {
   std::tie(m_regex_definition, m_type_info) =
       create_regex_definition(add_escape_chars(m_definition));
+  m_regex = std::regex(m_regex_definition);
 }
 const std::string& step_definition::function_name() const noexcept
 {
@@ -38,6 +38,7 @@ const std::string& step_definition::regex_string() const noexcept
 {
   return m_regex_definition;
 }
+const std::regex& step_definition::regex() const noexcept { return m_regex; }
 void step_definition::call(const value_array& values, const doc_string& doc_str,
                            const table& t) const
 {

--- a/src/step.hpp
+++ b/src/step.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <vector>
 #include <string>
+#include <regex>
 
 #include "value.hpp"
 #include "param_info.hpp"
@@ -37,6 +38,7 @@ class step_definition
   const std::string& definition() const noexcept;
   const std::vector<param_info>& type_info() const noexcept;
   const std::string& regex_string() const noexcept;
+  const std::regex& regex() const noexcept;
   std::string source_location() const noexcept;
   void call(const value_array& values, const doc_string& doc_str,
             const table& t) const;
@@ -46,6 +48,7 @@ class step_definition
   step_callback m_callback;
   std::string m_definition;
   std::string m_regex_definition;
+  std::regex m_regex;
   std::vector<param_info> m_type_info;
   std::string m_function_name;
   std::string m_file;

--- a/src/step_finder.cpp
+++ b/src/step_finder.cpp
@@ -21,7 +21,10 @@ step_finder::step_finder(std::string_view feature,
 cuke::value_array& step_finder::values() noexcept { return m_values; }
 bool step_finder::step_matches(const std::string& pattern)
 {
-  std::regex regex_pattern(pattern);
+  return step_matches(std::regex(pattern));
+}
+bool step_finder::step_matches(const std::regex& regex_pattern)
+{
   std::smatch match;
   if (std::regex_match(m_feature_string, match, regex_pattern))
   {

--- a/src/step_finder.hpp
+++ b/src/step_finder.hpp
@@ -3,6 +3,7 @@
 #include <optional>
 #include <string_view>
 #include <algorithm>
+#include <regex>
 
 #include "value.hpp"
 #include "table.hpp"
@@ -18,6 +19,7 @@ class step_finder
               std::optional<cuke::table::row> hash_row = std::nullopt);
 
   [[nodiscard]] bool step_matches(const std::string& pattern);
+  [[nodiscard]] bool step_matches(const std::regex& pattern);
   [[nodiscard]] cuke::value_array& values() noexcept;
 
   template <typename Iterator>
@@ -25,7 +27,7 @@ class step_finder
   {
     return std::find_if(first, last,
                         [this](const cuke::internal::step_definition& s)
-                        { return step_matches(s.regex_string()); });
+                        { return step_matches(s.regex()); });
   }
 
  private:


### PR DESCRIPTION
## Cache compiled step regex to avoid recompiling on every match

**What**
`step_finder::step_matches()` previously compiled a new `std::regex` from a step's pattern string on every match attempt — i.e. once per step definition checked against every step in every scenario. `step_definition` already builds its regex pattern string once at registration time, but never compiled it into a reusable `std::regex` object.

**Change**
- `step_definition` now compiles and stores a `std::regex` once in its constructor, exposed via a new `regex()` accessor (alongside the existing `regex_string()`).
- `step_finder` gains a `step_matches(const std::regex&)` overload that does the actual matching against a precompiled regex. `find()` now uses it via `s.regex()`.
- The existing `step_matches(const std::string&)` overload is kept (delegates to the new one) for backward compatibility — no changes needed in existing unit tests.

**Why**
Regex compilation is significantly more expensive than matching. This turns an O(definitions × steps) recompilation cost into a one-time O(definitions) cost at registration.

**Testing**
All existing unit/integration tests pass unchanged; no behavioral change, matching semantics identical.